### PR TITLE
fix to publish to npm with npm v9

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+fixture

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ftpd",
+  "name": "@activeprospect/ftpd",
   "version": "0.2.14",
   "description": "Node FTP Server",
   "main": "./ftpd.js",


### PR DESCRIPTION
## Description of the change

The (intentionally) weird paths in this packages `fixture` directory are causing errors with npm v9 when Batch API tries to install it from GitHub. This PR is intended to make this forked package publishable to npm, without those weird fixture paths, and allow installation from there.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/47114/upgrade-batch-to-node-v18?vc_group_by=day&ct_workflow=all&cf_workflow=500000005

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
